### PR TITLE
iTerm 2.1.1: remove trailing whitespace

### DIFF
--- a/custom_iterm_script_iterm_2.1.1.applescript
+++ b/custom_iterm_script_iterm_2.1.1.applescript
@@ -23,7 +23,7 @@ on alfred_script(q)
 		end run" with parameters {q}
 	else
 		run script "
-			on run {q} 
+			on run {q}
 				tell application \":Applications:iTerm.app\"
 					activate
 					tell the first terminal


### PR DESCRIPTION
Also fixes the “no newline at end of file” warning. Those are [actually meaningful](http://unix.stackexchange.com/a/18789).