### PR TITLE
iTerm 2.9: fixes whitespace

### DIFF
--- a/custom_iterm_script_iterm_2.9.applescript
+++ b/custom_iterm_script_iterm_2.9.applescript
@@ -11,17 +11,17 @@ on alfred_script(q)
 		run script "
 			on run {q}
 			tell application \":Applications:iTerm.app\"
-				activate    
+				activate
 				try
-     				select first window
+						select first window
 					set onlywindow to false
-				on error 
-    					create window with default profile
+				on error
+							create window with default profile
 					select first window
 					set onlywindow to true
 				end try
 				tell the first window
-					if onlywindow is false then 
+					if onlywindow is false then
 					create tab with default profile
 					end if
 					tell current session
@@ -32,13 +32,13 @@ on alfred_script(q)
 		end run" with parameters {"q"}
 	else
 		run script "
-		on run {q} 
+		on run {q}
 			tell application \":Applications:iTerm.app\"
 				activate
 				try
-     				select first window
-				on error 
-    				create window with default profile
+						select first window
+				on error
+						create window with default profile
 					select first window
 				end try
 				tell the first window


### PR DESCRIPTION
Removes trailing whitespace, adds newline at end, and converts spaces to tabs (both were being used).