### PR TITLE
custom_iterm_script_iterm_2.1.1.applescript: cosmetic consistency improvements

### DIFF
--- a/custom_iterm_script_iterm_2.1.1.applescript
+++ b/custom_iterm_script_iterm_2.1.1.applescript
@@ -1,5 +1,5 @@
-on is_running(appName)
-	tell application "System Events" to (name of processes) contains appName
+on is_running(app_name)
+	tell application "System Events" to (name of processes) contains app_name
 end is_running
 
 -- Please note, if you store the iTerm binary in any other location than the Applications Folder
@@ -10,28 +10,25 @@ on alfred_script(q)
 	if is_running("iTerm") then
 		run script "
 			on run {q}
-
-			tell application \":Applications:iTerm.app\"
-				activate
-				tell the first terminal
-					set mysession to (launch session \"Default Session\")
-					tell mysession
-						write text q
+				tell application \":Applications:iTerm.app\"
+					activate
+					tell the first terminal
+						set mysession to (launch session \"Default Session\")
+						tell mysession to write text q
 					end tell
 				end tell
-			end tell
-		end run" with parameters {q}
+			end run
+		" with parameters {q}
 	else
 		run script "
 			on run {q}
 				tell application \":Applications:iTerm.app\"
 					activate
 					tell the first terminal
-						tell the last session
-							write text q
-						end tell
+						tell the last session to write text q
 					end tell
 				end tell
-			end run" with parameters {q}
+			end run
+		" with parameters {q}
 	end if
 end alfred_script


### PR DESCRIPTION
+ Some places used camelCase while others used_underscores
+ Some used the single line tell…to when available while others didn’t
    + Exception still made for 'tell the first terminal' since they’d become inconsistent with this rule applied
+ Indentation regarding where 'run script' ends is now clearer.
+ Deleted inconsistent blank line after first 'on run'
+ Corrected indentation inside first 'on run'