### PR TITLE
custom_iterm_script_iterm_2.9.applescript: cosmetic consistency improvements

### DIFF
--- a/custom_iterm_script_iterm_2.9.applescript
+++ b/custom_iterm_script_iterm_2.9.applescript
@@ -1,5 +1,5 @@
-on is_running(appName)
-	tell application "System Events" to (name of processes) contains appName
+on is_running(app_name)
+	tell application "System Events" to (name of processes) contains app_name
 end is_running
 
 -- Please note, if you store the iTerm binary in any other location than the Applications Folder
@@ -10,43 +10,41 @@ on alfred_script(q)
 	if is_running("iTerm2") or is_running("iTerm") then
 		run script "
 			on run {q}
-			tell application \":Applications:iTerm.app\"
-				activate
-				try
+				tell application \":Applications:iTerm.app\"
+					activate
+					try
 						select first window
-					set onlywindow to false
-				on error
-							create window with default profile
-					select first window
-					set onlywindow to true
-				end try
-				tell the first window
-					if onlywindow is false then
-					create tab with default profile
-					end if
-					tell current session
-						write text q
+						set onlywindow to false
+					on error
+						create window with default profile
+						select first window
+						set onlywindow to true
+					end try
+					tell the first window
+						if onlywindow is false then
+							create tab with default profile
+						end if
+						tell current session to write text q
 					end tell
 				end tell
-			end tell
-		end run" with parameters {q}
+			end run
+		" with parameters {q}
 	else
 		run script "
-		on run {q}
-			tell application \":Applications:iTerm.app\"
-				activate
-				try
+			on run {q}
+				tell application \":Applications:iTerm.app\"
+					activate
+					try
 						select first window
-				on error
+					on error
 						create window with default profile
-					select first window
-				end try
-				tell the first window
-					tell current session
-						write text q
+						select first window
+					end try
+					tell the first window
+						tell current session to write text q
 					end tell
 				end tell
-			end tell
-		end run" with parameters {q}
+			end run
+		" with parameters {q}
 	end if
 end alfred_script


### PR DESCRIPTION
+ Some places used camelCase while others used_underscores
+ Some used the single line tell…to when available while others didn’t
    + Exception still made for 'tell the first terminal' since they’d become inconsistent with this rule applied
+ Indentation regarding where 'run script' ends is now clearer.
+ Corrected indentation in general