### PR TITLE
Prevent multiple tabs opening in v3.0.6 #26

### DIFF
--- a/custom_iterm_script_iterm_2.9.applescript
+++ b/custom_iterm_script_iterm_2.9.applescript
@@ -14,7 +14,7 @@ on alfred_script(q)
 					activate
 					try
 						select first window
-						set onlywindow to false
+						set onlywindow to true
 					on error
 						create window with default profile
 						select first window


### PR DESCRIPTION
Ran into the same problem in issue #26. Setting `true` prevents multiple tabs from opening.
