### PR TITLE
Update onlywindow flag to support tabs

### DIFF
--- a/custom_iterm_script_iterm_3.1.1.applescript
+++ b/custom_iterm_script_iterm_3.1.1.applescript
@@ -9,7 +9,7 @@ on alfred_script(q)
 					activate
 					try
 						select first window
-						set onlywindow to true
+						set onlywindow to false
 					on error
 						create window with default profile
 						select first window


### PR DESCRIPTION
The current version for 3.1 doesn't run new commands in a tab. This is because the onlywindow flag isn't set properly in all cases. This PR fixes it.